### PR TITLE
Do not log a warning if a component cannot be loaded.

### DIFF
--- a/lib/libraries/cms/component/helper.php
+++ b/lib/libraries/cms/component/helper.php
@@ -240,10 +240,6 @@ class JComponentHelper
 
 		if (empty(static::$components[$option]))
 		{
-			// Fatal error.
-			$error = JText::_('JLIB_APPLICATION_ERROR_COMPONENT_NOT_FOUND');
-			JLog::add(JText::sprintf('JLIB_APPLICATION_ERROR_COMPONENT_NOT_LOADING', $option, $error), JLog::WARNING, 'jerror');
-
 			return false;
 		}
 


### PR DESCRIPTION
resolve #179 
