### PR TITLE
Improve 404 redirect plugin

### DIFF
--- a/lib/plugins/system/404/404.php
+++ b/lib/plugins/system/404/404.php
@@ -27,14 +27,21 @@ class PlgSystem404 extends JPlugin
 
         if ($app->get('sef') && (int) $error->getCode() == 404)
         {
+            $menu        = $app->getMenu()->getActive();
+            $menu_prefix = JRoute::_($menu->link, false);
+            $subpath     = preg_replace('#'.preg_quote(JURI::base(true)).'#', '', $menu_prefix, 1);
+            $path        = JUri::base() . ltrim($subpath, '/');
+            $path        = '/'. ltrim(preg_replace('#'.preg_quote($path).'#', '', JUri::current(), 1), '/');
+
             $regex   = '/\/[\d]+\-/';
-            $current = JUri::current();
 
             // Match url having "/xxx-" format, where xxx is a number.
-            if (preg_match($regex, $current))
+            if (preg_match($regex, $path))
             {
                 // Redirect with-id to no-id url
-                $redirect = preg_replace($regex, '/', $current);
+                $redirect = preg_replace($regex, '/', $path);
+                $redirect = '/' . ltrim($menu_prefix . $redirect, '/');
+
                 $app->redirect($redirect);
             }
         }

--- a/lib/plugins/system/404/404.php
+++ b/lib/plugins/system/404/404.php
@@ -29,19 +29,29 @@ class PlgSystem404 extends JPlugin
         {
             $menu        = $app->getMenu()->getActive();
             $menu_prefix = JRoute::_($menu->link, false);
-            $subpath     = preg_replace('#'.preg_quote(JURI::base(true)).'#', '', $menu_prefix, 1);
-            $path        = JUri::base() . ltrim($subpath, '/');
-            $path        = '/'. ltrim(preg_replace('#'.preg_quote($path).'#', '', JUri::current(), 1), '/');
+            $subpath     = $menu_prefix;
 
-            $regex   = '/\/[\d]+\-/';
+            if ($base = JURI::base(true)) {
+                $subpath = preg_replace('#^'.preg_quote($base).'#', '', $menu_prefix, 1);
+            }
 
-            // Match url having "/xxx-" format, where xxx is a number.
-            if (preg_match($regex, $path))
+            $path = JUri::base() . ltrim($subpath, '/');
+            $path = ltrim(preg_replace('#^'.preg_quote($path).'#', '', JUri::current(), 1), '/');
+
+            $redirect = false;
+            // category redirect, redirect to path-without-leading-id
+            if (preg_match('#^([0-9]+)\-(.+)$#i', $path, $matches)) {
+                $redirect = $matches[2];
+            }
+            // article redirect, redirect to path-until-article/article-alias-without-id
+            elseif (preg_match('#(.*\/)+([0-9]+)\-(.+)$#i', $path, $matches))
             {
-                // Redirect with-id to no-id url
-                $redirect = preg_replace($regex, '/', $path);
-                $redirect = '/' . ltrim($menu_prefix . $redirect, '/');
+                $redirect = $matches[1] . $matches[3];
+            }
 
+            if ($redirect)
+            {
+                $redirect = $menu_prefix . '/' . $redirect;
                 $app->redirect($redirect);
             }
         }


### PR DESCRIPTION
Closes #353

- Handle platform running in subdirectory
- Dont include menu subpath when preparing the url to no-id

In this PR i kept the regex that will remove all the ids in the url `/xxx-` to `/`. No need to redirect twice to remove the category id then the article id.