### PR TITLE
Adding a Check for Empty $sessionQueue

### DIFF
--- a/lib/libraries/cms/application/cms.php
+++ b/lib/libraries/cms/application/cms.php
@@ -462,7 +462,7 @@ class JApplicationCms extends JApplicationWeb
 			$session = JFactory::getSession();
 			$sessionQueue = $session->get('application.queue');
 
-			if (count($sessionQueue))
+			if (!empty($sessionQueue) && count($sessionQueue))
 			{
 				$this->_messageQueue = $sessionQueue;
 				$session->set('application.queue', null);


### PR DESCRIPTION
This prevents a warning shared in Ticket #10006 on the Joomlatools website. Running the platform on Windows, this warning would pop up when accessing the backend interface.